### PR TITLE
Add thread run state string to report

### DIFF
--- a/Samples/Tests/Core/PartialCrashReport.swift
+++ b/Samples/Tests/Core/PartialCrashReport.swift
@@ -70,6 +70,7 @@ struct PartialCrashReport: Decodable {
             }
 
             var index: Int
+            var state: String
             var crashed: Bool
             var backtrace: Backtrace
         }

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -129,6 +129,12 @@ final class OtherTests: IntegrationTestBase {
         })
         XCTAssertNotNil(expectedFrame)
 
+        var threadStates = ["TH_STATE_RUNNING", "TH_STATE_STOPPED", "TH_STATE_WAITING",
+                            "TH_STATE_UNINTERRUPTIBLE", "TH_STATE_HALTED"]
+        for thread in rawReport.crash?.threads  ?? [] {
+            XCTAssertTrue(threadStates.contains(thread.state))
+        }
+
         let appleReport = try launchAndReportCrash()
         XCTAssertTrue(appleReport.contains(KSCrashStacktraceCheckFuncName))
     }

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1038,11 +1038,15 @@ static void writeNotableAddresses(const KSCrashReportWriter *const writer, const
  *
  * @param machineContext The context whose thread to write about.
  *
+ * @param threadIndex The index of the thread.
+ *
  * @param shouldWriteNotableAddresses If true, write any notable addresses found.
+ *
+ * @param threadState The state code of the thread.
  */
 static void writeThread(const KSCrashReportWriter *const writer, const char *const key,
                         const KSCrash_MonitorContext *const crash, const struct KSMachineContext *const machineContext,
-                        const int threadIndex, const bool shouldWriteNotableAddresses)
+                        const int threadIndex, const bool shouldWriteNotableAddresses, const int threadState)
 {
     bool isCrashedThread = ksmc_isCrashedContext(machineContext);
     KSThread thread = ksmc_getThreadFromContext(machineContext);
@@ -1050,6 +1054,7 @@ static void writeThread(const KSCrashReportWriter *const writer, const char *con
 
     KSStackCursor stackCursor;
     bool hasBacktrace = getStackCursor(crash, machineContext, &stackCursor);
+    const char* state = ksthread_state_name(threadState);
 
     writer->beginObject(writer, key);
     {
@@ -1067,6 +1072,9 @@ static void writeThread(const KSCrashReportWriter *const writer, const char *con
         name = ksccd_getQueueName(thread);
         if (name != NULL) {
             writer->addStringElement(writer, KSCrashField_DispatchQueue, name);
+        }
+        if (state != NULL) {
+            writer->addStringElement(writer, KSCrashField_State, state);
         }
         writer->addBooleanElement(writer, KSCrashField_Crashed, isCrashedThread);
         writer->addBooleanElement(writer, KSCrashField_CurrentThread, thread == ksthread_self());
@@ -1102,11 +1110,13 @@ static void writeAllThreads(const KSCrashReportWriter *const writer, const char 
         KSLOG_DEBUG("Writing %d threads.", threadCount);
         for (int i = 0; i < threadCount; i++) {
             KSThread thread = ksmc_getThreadAtIndex(context, i);
+            int threadRunState = 0;
+            ksthread_getThreadState(thread, &threadRunState);
             if (thread == offendingThread) {
-                writeThread(writer, NULL, crash, context, i, writeNotableAddresses);
+                writeThread(writer, NULL, crash, context, i,  writeNotableAddresses, threadRunState);
             } else {
                 ksmc_getContextForThread(thread, machineContext, false);
-                writeThread(writer, NULL, crash, machineContext, i, writeNotableAddresses);
+                writeThread(writer, NULL, crash, machineContext, i, writeNotableAddresses, threadRunState);
             }
         }
     }
@@ -1472,10 +1482,12 @@ void kscrashreport_writeRecrashReport(const KSCrash_MonitorContext *const monito
         {
             writeError(writer, KSCrashField_Error, monitorContext);
             ksfu_flushBufferedWriter(&bufferedWriter);
-            int threadIndex = ksmc_indexOfThread(monitorContext->offendingMachineContext,
-                                                 ksmc_getThreadFromContext(monitorContext->offendingMachineContext));
+            KSThread thread = ksmc_getThreadFromContext(monitorContext->offendingMachineContext);
+            int threadIndex = ksmc_indexOfThread(monitorContext->offendingMachineContext, thread);
+            int threadRunState = 0;
+            ksthread_getThreadState(thread, &threadRunState);
             writeThread(writer, KSCrashField_CrashedThread, monitorContext, monitorContext->offendingMachineContext,
-                        threadIndex, false);
+                        threadIndex, false, threadRunState);
             ksfu_flushBufferedWriter(&bufferedWriter);
         }
         writer->endContainer(writer);

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1113,7 +1113,7 @@ static void writeAllThreads(const KSCrashReportWriter *const writer, const char 
             int threadRunState = 0;
             ksthread_getThreadState(thread, &threadRunState);
             if (thread == offendingThread) {
-                writeThread(writer, NULL, crash, context, i,  writeNotableAddresses, threadRunState);
+                writeThread(writer, NULL, crash, context, i, writeNotableAddresses, threadRunState);
             } else {
                 ksmc_getContextForThread(thread, machineContext, false);
                 writeThread(writer, NULL, crash, machineContext, i, writeNotableAddresses, threadRunState);

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1110,8 +1110,7 @@ static void writeAllThreads(const KSCrashReportWriter *const writer, const char 
         KSLOG_DEBUG("Writing %d threads.", threadCount);
         for (int i = 0; i < threadCount; i++) {
             KSThread thread = ksmc_getThreadAtIndex(context, i);
-            int threadRunState = 0;
-            ksthread_getThreadState(thread, &threadRunState);
+            int threadRunState = ksthread_getThreadState(thread);
             if (thread == offendingThread) {
                 writeThread(writer, NULL, crash, context, i, writeNotableAddresses, threadRunState);
             } else {
@@ -1484,8 +1483,7 @@ void kscrashreport_writeRecrashReport(const KSCrash_MonitorContext *const monito
             ksfu_flushBufferedWriter(&bufferedWriter);
             KSThread thread = ksmc_getThreadFromContext(monitorContext->offendingMachineContext);
             int threadIndex = ksmc_indexOfThread(monitorContext->offendingMachineContext, thread);
-            int threadRunState = 0;
-            ksthread_getThreadState(thread, &threadRunState);
+            int threadRunState = ksthread_getThreadState(thread);
             writeThread(writer, KSCrashField_CrashedThread, monitorContext, monitorContext->offendingMachineContext,
                         threadIndex, false, threadRunState);
             ksfu_flushBufferedWriter(&bufferedWriter);

--- a/Sources/KSCrashRecording/include/KSCrashReportFields.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportFields.h
@@ -136,6 +136,7 @@ KSCRF_DEFINE_CONSTANT(KSCrashField, NotableAddresses, notableAddresses, "notable
 KSCRF_DEFINE_CONSTANT(KSCrashField, Registers, registers, "registers")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Skipped, skipped, "skipped")
 KSCRF_DEFINE_CONSTANT(KSCrashField, Stack, stack, "stack")
+KSCRF_DEFINE_CONSTANT(KSCrashField, State, state, "state")
 
 #pragma mark - Binary Image -
 

--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -72,8 +72,10 @@ bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLe
     return pthread_getname_np(pthread, buffer, (unsigned)bufLength) == 0;
 }
 
-bool ksthread_getThreadState(const KSThread thread, int* threadState)
+int ksthread_getThreadState(const KSThread thread)
 {
+    int threadState = TH_STATE_UNSET;
+
     integer_t infoBuffer[THREAD_BASIC_INFO_COUNT] = {0};
     thread_info_t info = infoBuffer;
     mach_msg_type_number_t inOutSize = THREAD_BASIC_INFO_COUNT;
@@ -84,17 +86,18 @@ bool ksthread_getThreadState(const KSThread thread, int* threadState)
         KSLOG_TRACE("Error getting thread_info with flavor "
                         "THREAD_BASIC_INFO from mach thread : %s",
                         mach_error_string(kr));
-        return false;
+        return threadState;
     }
+
 
     thread_basic_info_t basicInfo = (thread_basic_info_t)info;
     if (!ksmem_isMemoryReadable(basicInfo, sizeof(*basicInfo))) {
         KSLOG_DEBUG("Thread %p has an invalid thread basic info %p", thread, basicInfo);
-        return false;
+        return threadState;
     }
-    *threadState = basicInfo->run_state;
+    threadState = basicInfo->run_state;
 
-    return true;
+    return threadState;
 }
 
 bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLength)

--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -57,7 +57,6 @@ const char *ksthread_state_name(int state) {
     return thread_state_names[state];
 }
 
-
 KSThread ksthread_self(void)
 {
     thread_t thread_self = mach_thread_self();

--- a/Sources/KSCrashRecordingCore/KSThread.c
+++ b/Sources/KSCrashRecordingCore/KSThread.c
@@ -32,10 +32,31 @@
 // #define KSLogger_LocalLevel TRACE
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
+#include <mach/thread_info.h>
 #include <pthread.h>
 #include <sys/sysctl.h>
 
 #include "KSLogger.h"
+
+static const char* thread_state_names[] = {
+    // Defined in mach/thread_info.h
+    NULL,
+    "TH_STATE_RUNNING",
+    "TH_STATE_STOPPED",
+    "TH_STATE_WAITING",
+    "TH_STATE_UNINTERRUPTIBLE",
+    "TH_STATE_HALTED",
+};
+
+static const int thread_state_names_count = sizeof(thread_state_names) / sizeof(*thread_state_names);
+
+const char *ksthread_state_name(int state) {
+    if (state < 1 || state >= thread_state_names_count) {
+        return NULL;
+    }
+    return thread_state_names[state];
+}
+
 
 KSThread ksthread_self(void)
 {
@@ -50,6 +71,31 @@ bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLe
 
     const pthread_t pthread = pthread_from_mach_thread_np((thread_t)thread);
     return pthread_getname_np(pthread, buffer, (unsigned)bufLength) == 0;
+}
+
+bool ksthread_getThreadState(const KSThread thread, int* threadState)
+{
+    integer_t infoBuffer[THREAD_BASIC_INFO_COUNT] = {0};
+    thread_info_t info = infoBuffer;
+    mach_msg_type_number_t inOutSize = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = 0;
+
+    kr = thread_info((thread_t)thread, THREAD_BASIC_INFO, info, &inOutSize);
+    if (kr != KERN_SUCCESS) {
+        KSLOG_TRACE("Error getting thread_info with flavor "
+                        "THREAD_BASIC_INFO from mach thread : %s",
+                        mach_error_string(kr));
+        return false;
+    }
+
+    thread_basic_info_t basicInfo = (thread_basic_info_t)info;
+    if (!ksmem_isMemoryReadable(basicInfo, sizeof(*basicInfo))) {
+        KSLOG_DEBUG("Thread %p has an invalid thread basic info %p", thread, basicInfo);
+        return false;
+    }
+    *threadState = basicInfo->run_state;
+
+    return true;
 }
 
 bool ksthread_getQueueName(const KSThread thread, char *const buffer, int bufLength)

--- a/Sources/KSCrashRecordingCore/include/KSThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSThread.h
@@ -36,12 +36,20 @@ extern "C" {
 
 typedef uintptr_t KSThread;
 
+/** Convert thread state code to a state string.
+ *
+ * @param state The thread state code.
+ *
+ * @return thread state name.
+ */
+const char *ksthread_state_name(int state);
+
 /** Get a thread's name. Internally, a thread name will
  * never be more than 64 characters long.
  *
  * @param thread The thread whose name to get.
  *
- * @oaram buffer Buffer to hold the name.
+ * @param buffer Buffer to hold the name.
  *
  * @param bufLength The length of the buffer.
  *
@@ -49,12 +57,22 @@ typedef uintptr_t KSThread;
  */
 bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLength);
 
+/** Get a thread's state.
+ *
+ * @param thread The thread whose state to get.
+ *
+ * @param threadState Pointer to the threadState value.
+ *
+ * @return true if state was found.
+ */
+bool ksthread_getThreadState(const KSThread thread, int* threadState);
+
 /** Get the name of a thread's dispatch queue. Internally, a queue name will
  * never be more than 64 characters long.
  *
  * @param thread The thread whose queue name to get.
  *
- * @oaram buffer Buffer to hold the name.
+ * @param buffer Buffer to hold the name.
  *
  * @param bufLength The length of the buffer.
  *

--- a/Sources/KSCrashRecordingCore/include/KSThread.h
+++ b/Sources/KSCrashRecordingCore/include/KSThread.h
@@ -34,6 +34,10 @@
 extern "C" {
 #endif
 
+/** Default value for the thread state
+ */
+#define TH_STATE_UNSET 0
+
 typedef uintptr_t KSThread;
 
 /** Convert thread state code to a state string.
@@ -61,11 +65,9 @@ bool ksthread_getThreadName(const KSThread thread, char *const buffer, int bufLe
  *
  * @param thread The thread whose state to get.
  *
- * @param threadState Pointer to the threadState value.
- *
- * @return true if state was found.
+ * @return Thread state integer code, default value is TH_STATE_UNSET
  */
-bool ksthread_getThreadState(const KSThread thread, int* threadState);
+int ksthread_getThreadState(const KSThread thread);
 
 /** Get the name of a thread's dispatch queue. Internally, a queue name will
  * never be more than 64 characters long.

--- a/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
+++ b/Tests/KSCrashRecordingCoreTests/KSThread_Tests.m
@@ -62,4 +62,19 @@
     XCTAssertTrue(success, @"");
 }
 
+- (void) testStateName
+{
+    int state = 0;
+    const char* stateName = ksthread_state_name(state);
+    XCTAssertEqual(stateName, NULL);
+
+    state = 8;
+    stateName = ksthread_state_name(state);
+    XCTAssertEqual(stateName, NULL);
+
+    state = 2;
+    stateName = ksthread_state_name(state);
+    NSString *stateString = @"TH_STATE_STOPPED";
+    XCTAssertEqual(strcmp(stateName,  stateString.UTF8String), 0);
+}
 @end


### PR DESCRIPTION
Extract thread running state code and convert it to string representation - enum names in `mach/thread_info.h`.
Added unit and integration tests.