### PR TITLE
Add async safety status flag in crash callback

### DIFF
--- a/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
+++ b/Samples/Common/Sources/LibraryBridge/InstallBridge.swift
@@ -76,6 +76,9 @@ public class InstallBridge: ObservableObject {
 
     public init() {
         config = .init()
+        config.crashNotifyCallback = { (writer, requiresAsyncSafety) -> Void in
+            Self.logger.info("User callback has requireAsyncSafety value: \(String(requiresAsyncSafety))")
+         }
 
         $basePath
             .removeDuplicates()

--- a/Samples/Tests/IntegrationTests.swift
+++ b/Samples/Tests/IntegrationTests.swift
@@ -129,7 +129,7 @@ final class OtherTests: IntegrationTestBase {
         })
         XCTAssertNotNil(expectedFrame)
 
-        var threadStates = ["TH_STATE_RUNNING", "TH_STATE_STOPPED", "TH_STATE_WAITING",
+        let threadStates = ["TH_STATE_RUNNING", "TH_STATE_STOPPED", "TH_STATE_WAITING",
                             "TH_STATE_UNINTERRUPTIBLE", "TH_STATE_HALTED"]
         for thread in rawReport.crash?.threads  ?? [] {
             XCTAssertTrue(threadStates.contains(thread.state))

--- a/Sources/KSCrashInstallations/KSCrashInstallation.m
+++ b/Sources/KSCrashInstallations/KSCrashInstallation.m
@@ -238,7 +238,7 @@ static CrashHandlerData *g_crashHandlerData;
     @synchronized(handler) {
         g_crashHandlerData = self.crashHandlerData;
 
-        configuration.crashNotifyCallback = ^(const struct KSCrashReportWriter *_Nonnull writer) {
+        configuration.crashNotifyCallback = ^(const struct KSCrashReportWriter *_Nonnull writer, bool requiresAsyncSafety) {
             CrashHandlerData *crashHandlerData = g_crashHandlerData;
             if (crashHandlerData == NULL) {
                 return;
@@ -250,7 +250,7 @@ static CrashHandlerData *g_crashHandlerData;
                 }
             }
             if (crashHandlerData->userCrashCallback != NULL) {
-                crashHandlerData->userCrashCallback(writer);
+                crashHandlerData->userCrashCallback(writer, requiresAsyncSafety);
             }
         };
 

--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1619,7 +1619,7 @@ void kscrashreport_writeStandardReport(const KSCrash_MonitorContext *const monit
         }
         if (g_userSectionWriteCallback != NULL) {
             ksfu_flushBufferedWriter(&bufferedWriter);
-            g_userSectionWriteCallback(writer);
+            g_userSectionWriteCallback(writer, monitorContext->requiresAsyncSafety);
         }
         writer->endContainer(writer);
         ksfu_flushBufferedWriter(&bufferedWriter);

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * **Default**: NULL
  */
-@property(nonatomic, copy, nullable) void (^crashNotifyCallback)(const struct KSCrashReportWriter *writer);
+@property(nonatomic, copy, nullable) void (^crashNotifyCallback)(const struct KSCrashReportWriter *writer, bool requiresAsyncSafety);
 
 /** Callback to invoke upon finishing writing a crash report.
  *

--- a/Sources/KSCrashRecording/include/KSCrashReportWriter.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportWriter.h
@@ -225,7 +225,7 @@ typedef struct KSCrashReportWriter {
 
 } NS_SWIFT_NAME(ReportWriter) KSCrashReportWriter;
 
-typedef void (*KSReportWriteCallback)(const KSCrashReportWriter *writer)
+typedef void (*KSReportWriteCallback)(const KSCrashReportWriter *writer, bool requiresAsyncSafety)
     NS_SWIFT_UNAVAILABLE("Use Swift closures instead!");
 
 #ifdef __cplusplus


### PR DESCRIPTION
Added `requiresAsyncSafety` flag to user on crash callback.

Tests: Added log statement in the test app to manually check async safety flag value on different crashes.