### PR TITLE
Add procTranslated and freeStorageSize fields to system info

### DIFF
--- a/Sources/KSCrashDiscSpaceMonitor/KSCrashMonitor_DiscSpace.m
+++ b/Sources/KSCrashDiscSpaceMonitor/KSCrashMonitor_DiscSpace.m
@@ -45,6 +45,13 @@ static uint64_t getStorageSize(void)
     return storageSize.unsignedLongLongValue;
 }
 
+static uint64_t getFreeStorageSize(void)
+{
+    NSNumber *freeStorageSize = [[[NSFileManager defaultManager] attributesOfFileSystemForPath:NSHomeDirectory() error:nil]
+        objectForKey:NSFileSystemFreeSize];
+    return freeStorageSize.unsignedLongLongValue;
+}
+
 #pragma mark - API -
 
 static const char *monitorId(void) { return "DiscSpace"; }
@@ -62,6 +69,7 @@ static void addContextualInfoToEvent(KSCrash_MonitorContext *eventContext)
 {
     if (g_isEnabled) {
         eventContext->System.storageSize = getStorageSize();
+        eventContext->System.freeStorageSize = getFreeStorageSize();
     }
 }
 

--- a/Sources/KSCrashRecording/KSCrash.m
+++ b/Sources/KSCrashRecording/KSCrash.m
@@ -201,6 +201,7 @@ static void currentSnapshotUserReportedExceptionHandler(NSException *exception)
     COPY_STRING(kernelVersion);
     COPY_STRING(osVersion);
     COPY_PRIMITIVE(isJailbroken);
+    COPY_PRIMITIVE(procTranslated);
     COPY_STRING(bootTime);  // this field is populated in an optional monitor
     COPY_STRING(appStartTime);
     COPY_STRING(executablePath);
@@ -222,6 +223,7 @@ static void currentSnapshotUserReportedExceptionHandler(NSException *exception)
     COPY_STRING(deviceAppHash);
     COPY_STRING(buildType);
     COPY_PRIMITIVE(storageSize);  // this field is populated in an optional monitor
+    COPY_PRIMITIVE(freeStorageSize);  // this field is populated in an optional monitor
     COPY_PRIMITIVE(memorySize);
     COPY_PRIMITIVE(freeMemory);
     COPY_PRIMITIVE(usableMemory);

--- a/Sources/KSCrashRecording/include/KSCrash.h
+++ b/Sources/KSCrashRecording/include/KSCrash.h
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Information about the operating system and environment.
  *
- * @note `bootTime` and `storageSize` are not populated in this property.
+ * @note `bootTime`, `storageSize`  and `freeStorageSize` are not populated in this property.
  * To access these values, refer to the optional
  * `KSCrashBootTimeMonitor` and `KSCrashDiscSpaceMonitor` modules.
  */

--- a/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
+++ b/Sources/KSCrashRecordingCore/include/KSCrashMonitorContext.h
@@ -189,6 +189,7 @@ typedef struct KSCrash_MonitorContext {
         const char *kernelVersion;
         const char *osVersion;
         bool isJailbroken;
+        bool procTranslated;
         const char *bootTime;
         const char *appStartTime;
         const char *executablePath;
@@ -210,6 +211,7 @@ typedef struct KSCrash_MonitorContext {
         const char *deviceAppHash;
         const char *buildType;
         uint64_t storageSize;
+        uint64_t freeStorageSize;
         uint64_t memorySize;
         uint64_t freeMemory;
         uint64_t usableMemory;


### PR DESCRIPTION
Changes needed as part of harmonization task of `BSG_KSSystemInfo` and newest `KSCrashMonitorContext`.