### PR TITLE
Expose function to get report path from report ID

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReportStore.m
+++ b/Sources/KSCrashRecording/KSCrashReportStore.m
@@ -179,6 +179,14 @@
     return [KSCrashReportDictionary reportWithValue:crashReport];
 }
 
+- (NSString *)crashReportPathForID:(int64_t)reportID
+{
+    char pathName[KSCRS_MAX_PATH_LENGTH];
+    kscrs_getReportPathForID(reportID, pathName, &_cConfig);
+    NSString *pathString = [NSString stringWithUTF8String:pathName];
+    return pathString;
+}
+
 - (NSArray<KSCrashReportDictionary *> *)allReports
 {
     int reportCount = kscrs_getReportCount(&_cConfig);

--- a/Sources/KSCrashRecording/KSCrashReportStoreC.c
+++ b/Sources/KSCrashRecording/KSCrashReportStoreC.c
@@ -232,6 +232,13 @@ char *kscrs_readReportAtPath(const char *path)
     return result;
 }
 
+void kscrs_getReportPathForID(int64_t reportID, char *path, const KSCrashReportStoreCConfiguration *const configuration)
+{
+    pthread_mutex_lock(&g_mutex);
+    getCrashReportPathByID(reportID, path, configuration);
+    pthread_mutex_unlock(&g_mutex);
+}
+
 char *kscrs_readReport(int64_t reportID, const KSCrashReportStoreCConfiguration *const configuration)
 {
     pthread_mutex_lock(&g_mutex);

--- a/Sources/KSCrashRecording/include/KSCrashReportStore.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportStore.h
@@ -120,6 +120,14 @@ NS_SWIFT_NAME(CrashReportStore)
  */
 - (nullable KSCrashReportDictionary *)reportForID:(int64_t)reportID NS_SWIFT_NAME(report(for:));
 
+/** Get report file path for specified ID.
+ *
+ * @param reportID An ID of report.
+ *
+ * @return Crash report file path.
+ */
+- (NSString *)crashReportPathForID:(int64_t)reportID;
+
 /** Delete all unsent reports.
  */
 - (void)deleteAllReports;

--- a/Sources/KSCrashRecording/include/KSCrashReportStoreC.h
+++ b/Sources/KSCrashRecording/include/KSCrashReportStoreC.h
@@ -88,6 +88,15 @@ char *kscrs_readReport(int64_t reportID, const KSCrashReportStoreCConfiguration 
  */
 char *kscrs_readReportAtPath(const char *path);
 
+/** Get a path for given report ID.
+ *
+ * @param reportID The report's ID.
+ * @param path Path to report to fill in.
+ * @param configuration The store configuretion (e.g. reports path, app name etc).
+ *
+ */
+void kscrs_getReportPathForID(int64_t reportID, char *path, const KSCrashReportStoreCConfiguration *const configuration);
+
 /** Add a custom report to the store.
  *
  * @param report The report's contents (must be JSON encoded).


### PR DESCRIPTION
For our send-at-crash callback functionality we need to know not only reportID but its path.