### PR TITLE
Fix off-by-1 error when fetching register values on arm64 that could …

### DIFF
--- a/Sources/KSCrashRecordingCore/KSCPU_arm64.c
+++ b/Sources/KSCrashRecordingCore/KSCPU_arm64.c
@@ -41,7 +41,7 @@
 static const char *g_registerNames[] = { "x0",  "x1",  "x2",  "x3",  "x4",  "x5",  "x6",  "x7",  "x8",
                                          "x9",  "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
                                          "x18", "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26",
-                                         "x27", "x28", "x29", "fp",  "lr",  "sp",  "pc",  "cpsr" };
+                                         "x27", "x28", "fp",  "lr",  "sp",  "pc",  "cpsr" };
 static const int g_registerNamesCount = sizeof(g_registerNames) / sizeof(*g_registerNames);
 
 static const char *g_exceptionRegisterNames[] = { "exception", "esr", "far" };
@@ -77,20 +77,32 @@ const char *kscpu_registerName(const int regNumber)
 
 uint64_t kscpu_registerValue(const KSMachineContext *const context, const int regNumber)
 {
-    if (regNumber <= 29) {
+    // _structs.h:
+    //    _STRUCT_ARM_THREAD_STATE64
+    //    {
+    //        __uint64_t __x[29]; /* General purpose registers x0-x28 */
+    //        __uint64_t __fp;    /* Frame pointer x29 */
+    //        __uint64_t __lr;    /* Link register x30 */
+    //        __uint64_t __sp;    /* Stack pointer x31 */
+    //        __uint64_t __pc;    /* Program counter */
+    //        __uint32_t __cpsr;  /* Current program status register */
+    //        __uint32_t __pad;   /* Same size for 32-bit or 64-bit clients */
+    //    };
+
+    if (regNumber <= 28) {
         return context->machineContext.__ss.__x[regNumber];
     }
 
     switch (regNumber) {
-        case 30:
+        case 29:
             return context->machineContext.__ss.__fp;
-        case 31:
+        case 30:
             return context->machineContext.__ss.__lr;
-        case 32:
+        case 31:
             return context->machineContext.__ss.__sp;
-        case 33:
+        case 32:
             return context->machineContext.__ss.__pc;
-        case 34:
+        case 33:
             return context->machineContext.__ss.__cpsr;
     }
 


### PR DESCRIPTION
…potentially run off the array.
Copied from: https://github.com/bugsnag/bugsnag-cocoa/pull/1635