### PR TITLE
Defensive copy cpp exception type

### DIFF
--- a/Sources/KSCrashRecordingCore/include/KSMemory.h
+++ b/Sources/KSCrashRecordingCore/include/KSMemory.h
@@ -36,6 +36,10 @@
 extern "C" {
 #endif
 
+#ifdef __cplusplus
+#define restrict __restrict__
+#endif
+
 /** Test if the specified memory is safe to read from.
  *
  * @param memory A pointer to the memory to test.


### PR DESCRIPTION
Runtime bug workaround: In some situations, `__cxa_current_exception_type` returns an invalid address.
Check to make sure it's in valid memory before we try to call `tinfo->name()`.