### PR TITLE
Symbolication fix, userInfo as proper JSON, self thread name

### DIFF
--- a/Sources/KSCrashRecording/KSCrashReportC.c
+++ b/Sources/KSCrashRecording/KSCrashReportC.c
@@ -1071,6 +1071,14 @@ static void writeThread(const KSCrashReportWriter *const writer, const char *con
         const char *name = ksccd_getThreadName(thread);
         if (name != NULL) {
             writer->addStringElement(writer, KSCrashField_Name, name);
+        } else {
+            // pthread_getname_np() acquires no locks if passed pthread_self() as
+            // of libpthread-330.201.1 (macOS 10.14 / iOS 12)
+            bool isSelfThread = thread == ksthread_self();
+            char threadName[64] = {0};
+            if (isSelfThread && !pthread_getname_np(pthread_self(), threadName, sizeof(threadName)) && threadName[0] != 0) {
+                writer->addStringElement(writer, KSCrashField_Name, threadName);
+            }
         }
         name = ksccd_getQueueName(thread);
         if (name != NULL) {

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_NSException.m
@@ -55,12 +55,9 @@ static NSUncaughtExceptionHandler *g_previousUncaughtExceptionHandler;
 #pragma mark - Helpers -
 // ============================================================================
 
-BOOL jsonDictionaryIsValid(NSDictionary *obj, NSError **error) {
+BOOL jsonDictionaryIsValid(NSDictionary *obj) {
     @try {
-        if (![obj isKindOfClass:[NSDictionary class]] || ![NSJSONSerialization isValidJSONObject:(id _Nonnull)obj]) {
-            return NO;
-        }
-        return YES;
+        return [obj isKindOfClass:[NSDictionary class]] && [NSJSONSerialization isValidJSONObject:(id _Nonnull)obj];
     } @catch (NSException *exception) {
         return NO;
     }
@@ -70,7 +67,7 @@ NSDictionary * prepareUserInfoDictionary(NSDictionary *dictionary) {
     if (!dictionary) {
         return nil;
     }
-    if (jsonDictionaryIsValid(dictionary, nil)) {
+    if (jsonDictionaryIsValid(dictionary)) {
         return dictionary;
     }
     NSMutableDictionary *json = [NSMutableDictionary dictionary];
@@ -79,7 +76,7 @@ NSDictionary * prepareUserInfoDictionary(NSDictionary *dictionary) {
             continue;
         }
         const id value = dictionary[key];
-        if (jsonDictionaryIsValid(@{key: value}, nil)) {
+        if (jsonDictionaryIsValid(@{key: value})) {
             json[key] = value;
         } else if ([value isKindOfClass:[NSDictionary class]]) {
             json[key] = prepareUserInfoDictionary(value);

--- a/Sources/KSCrashRecordingCore/KSSymbolicator.c
+++ b/Sources/KSCrashRecordingCore/KSSymbolicator.c
@@ -92,7 +92,7 @@ static int leb128_uintptr_decode(struct leb128_uintptr_context *context, uint8_t
 __attribute__((annotate("oclint:suppress[deep nested block]")))
 #endif
 bool kssymbolicator_symbolicate(KSStackCursor *cursor) {
-    uintptr_t instructionAddress = cursor->state.currentDepth == 1
+    uintptr_t instructionAddress = cursor->state.currentDepth == 0
                                     ? cursor->stackEntry.address
                                     : CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address);
 

--- a/Sources/KSCrashRecordingCore/KSSymbolicator.c
+++ b/Sources/KSCrashRecordingCore/KSSymbolicator.c
@@ -33,7 +33,7 @@
  * On armv7 the least significant bit of the pointer distinguishes
  * between thumb mode (2-byte instructions) and normal mode (4-byte instructions).
  * On arm64 all instructions are 4-bytes wide so the two least significant
- * bytes should always be 0.
+ * bits should always be 0.
  * On x86_64 and i386, instructions are variable length so all bits are
  * signficant.
  */
@@ -92,7 +92,7 @@ static int leb128_uintptr_decode(struct leb128_uintptr_context *context, uint8_t
 __attribute__((annotate("oclint:suppress[deep nested block]")))
 #endif
 bool kssymbolicator_symbolicate(KSStackCursor *cursor) {
-    uintptr_t instructionAddress = cursor->state.currentDepth == 0
+    uintptr_t instructionAddress = cursor->state.currentDepth == 1
                                     ? cursor->stackEntry.address
                                     : CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address);
 

--- a/Sources/KSCrashRecordingCore/KSSymbolicator.c
+++ b/Sources/KSCrashRecordingCore/KSSymbolicator.c
@@ -92,7 +92,9 @@ static int leb128_uintptr_decode(struct leb128_uintptr_context *context, uint8_t
 __attribute__((annotate("oclint:suppress[deep nested block]")))
 #endif
 bool kssymbolicator_symbolicate(KSStackCursor *cursor) {
-    uintptr_t instructionAddress = CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address);
+    uintptr_t instructionAddress = cursor->state.currentDepth == 1
+                                    ? cursor->stackEntry.address
+                                    : CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address);
 
     KSBinaryImage *image = ksdl_image_at_address(instructionAddress);
     if (!image || !image->header) {

--- a/Sources/KSCrashRecordingCore/KSSymbolicator.c
+++ b/Sources/KSCrashRecordingCore/KSSymbolicator.c
@@ -92,6 +92,7 @@ static int leb128_uintptr_decode(struct leb128_uintptr_context *context, uint8_t
 __attribute__((annotate("oclint:suppress[deep nested block]")))
 #endif
 bool kssymbolicator_symbolicate(KSStackCursor *cursor) {
+    // Cursor at 0 idx is a dummy so we start stack from 1
     uintptr_t instructionAddress = cursor->state.currentDepth == 1
                                     ? cursor->stackEntry.address
                                     : CALL_INSTRUCTION_FROM_RETURN_ADDRESS(cursor->stackEntry.address);


### PR DESCRIPTION
Added additional way to get thread name if it's not cached - but only for `self`.
Fixed instruction address in the symbolication, set object address for stackframe as main image address, not vmAddr.
Parsed NSException's userInfo to be a proper json string to be parsed on Bugsnag side.