### PR TITLE
Allow skipping threads in report, handle EXC_BAD_ACCESS, empty throw in cpp

### DIFF
--- a/Sources/KSCrashRecording/KSCrashC.c
+++ b/Sources/KSCrashRecording/KSCrashC.c
@@ -203,6 +203,7 @@ void handleConfiguration(KSCrashCConfiguration *configuration)
     }
 
     kscrashreport_setUserSectionWriteCallback(configuration->crashNotifyCallback);
+    kscrashreport_setThreadTracingEnabled(configuration->threadTracingEnabled);
     g_reportWrittenCallback = configuration->reportWrittenCallback;
     g_shouldAddConsoleLogToReport = configuration->addConsoleLogToReport;
     g_shouldPrintPreviousLog = configuration->printPreviousLogOnStartup;

--- a/Sources/KSCrashRecording/KSCrashConfiguration.m
+++ b/Sources/KSCrashRecording/KSCrashConfiguration.m
@@ -61,6 +61,7 @@
         _printPreviousLogOnStartup = cConfig.printPreviousLogOnStartup ? YES : NO;
         _enableSwapCxaThrow = cConfig.enableSwapCxaThrow ? YES : NO;
         _enableSigTermMonitoring = cConfig.enableSigTermMonitoring ? YES : NO;
+        _threadTracingEnabled = cConfig.threadTracingEnabled ? YES : NO;
 
         _reportStoreConfiguration = [KSCrashReportStoreConfiguration new];
         _reportStoreConfiguration.appName = nil;
@@ -104,6 +105,7 @@
     config.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     config.enableSwapCxaThrow = self.enableSwapCxaThrow;
     config.enableSigTermMonitoring = self.enableSigTermMonitoring;
+    config.threadTracingEnabled = self.threadTracingEnabled;
 
     return config;
 }
@@ -157,6 +159,7 @@
     copy.printPreviousLogOnStartup = self.printPreviousLogOnStartup;
     copy.enableSwapCxaThrow = self.enableSwapCxaThrow;
     copy.enableSigTermMonitoring = self.enableSigTermMonitoring;
+    copy.threadTracingEnabled = self.threadTracingEnabled;
     return copy;
 }
 

--- a/Sources/KSCrashRecording/KSCrashReportC.h
+++ b/Sources/KSCrashRecording/KSCrashReportC.h
@@ -79,6 +79,12 @@ void kscrashreport_setDoNotIntrospectClasses(const char **doNotIntrospectClasses
  */
 void kscrashreport_setUserSectionWriteCallback(const KSReportWriteCallback userSectionWriteCallback);
 
+/** Decide if all threads will be written to a report.
+ *
+ * @param threadTracingEnabled true if all threads should be recorded, if false, only the offending thread will be recorded.
+ */
+void kscrashreport_setThreadTracingEnabled(bool threadTracingEnabled);
+
 // ============================================================================
 #pragma mark - Main API -
 // ============================================================================

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -158,8 +158,8 @@ static void CPPExceptionTerminate(void)
         KSCrash_MonitorContext *crashContext = &g_monitorContext;
         memset(crashContext, 0, sizeof(*crashContext));
 
+        char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
         if (!emptyThrow) {
-            char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
             description = descriptionBuff;
             descriptionBuff[0] = 0;
 
@@ -169,7 +169,7 @@ static void CPPExceptionTerminate(void)
             try {
                 throw;
             } catch (std::exception &exc) {
-                strncpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
+                strlcpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
             }
 #define CATCH_VALUE(TYPE, PRINTFTYPE)                                                                \
 catch (TYPE value) { snprintf(descriptionBuff, sizeof(descriptionBuff), "%" #PRINTFTYPE, value); \

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -158,10 +158,9 @@ static void CPPExceptionTerminate(void)
         KSCrash_MonitorContext *crashContext = &g_monitorContext;
         memset(crashContext, 0, sizeof(*crashContext));
 
-        char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
+        char descriptionBuff[DESCRIPTION_BUFFER_LENGTH] = {0};
         if (!emptyThrow) {
             description = descriptionBuff;
-            descriptionBuff[0] = 0;
 
             KSLOG_DEBUG("Discovering what kind of exception was thrown.");
 

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_CPPException.cpp
@@ -39,12 +39,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <execinfo.h>
 
 #include <exception>
 #include <typeinfo>
 
 #include "KSCxaThrowSwapper.h"
 #include "KSLogger.h"
+#include "KSStackCursor_Backtrace.h"
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
@@ -74,6 +76,12 @@ static KSCrash_MonitorContext g_monitorContext;
 // TODO: Thread local storage is not supported < ios 9.
 // Find some other way to do thread local. Maybe storage with lookup by tid?
 static KSStackCursor g_stackCursor;
+
+/** Buffer for the backtrace of the most recent exception. */
+static uintptr_t g_stackTrace[STACKTRACE_BUFFER_LENGTH];
+
+/** Number of backtrace entries in the most recent exception. */
+static int g_stackTraceCount = 0;
 
 // ============================================================================
 #pragma mark - Callbacks -
@@ -130,11 +138,17 @@ static void CPPExceptionTerminate(void)
     KSLOG_DEBUG("Trapped c++ exception");
     const char *name = NULL;
     const char *description = NULL;
+    bool emptyThrow = false;
 
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
     if (tinfo == NULL) {
         name = "std::terminate";
         description = "throw may have been called without an exception";
+        emptyThrow = true;
+        if (!g_stackTraceCount) {
+            KSLOG_DEBUG("No exception backtrace");
+            g_stackTraceCount = backtrace((void **)g_stackTrace, sizeof(g_stackTrace) / sizeof(*g_stackTrace));
+        }
     } else {
         name = getExceptionTypeName(tinfo);
     }
@@ -144,35 +158,38 @@ static void CPPExceptionTerminate(void)
         KSCrash_MonitorContext *crashContext = &g_monitorContext;
         memset(crashContext, 0, sizeof(*crashContext));
 
-        char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
-        description = descriptionBuff;
-        descriptionBuff[0] = 0;
+        if (!emptyThrow) {
+            char descriptionBuff[DESCRIPTION_BUFFER_LENGTH];
+            description = descriptionBuff;
+            descriptionBuff[0] = 0;
 
-        KSLOG_DEBUG("Discovering what kind of exception was thrown.");
-        g_captureNextStackTrace = false;
-        try {
-            throw;
-        } catch (std::exception &exc) {
-            strncpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
-        }
+            KSLOG_DEBUG("Discovering what kind of exception was thrown.");
+
+            g_captureNextStackTrace = false;
+            try {
+                throw;
+            } catch (std::exception &exc) {
+                strncpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
+            }
 #define CATCH_VALUE(TYPE, PRINTFTYPE)                                                                \
-    catch (TYPE value) { snprintf(descriptionBuff, sizeof(descriptionBuff), "%" #PRINTFTYPE, value); \
-    }
-        CATCH_VALUE(char, d)
-        CATCH_VALUE(short, d)
-        CATCH_VALUE(int, d)
-        CATCH_VALUE(long, ld)
-        CATCH_VALUE(long long, lld)
-        CATCH_VALUE(unsigned char, u)
-        CATCH_VALUE(unsigned short, u)
-        CATCH_VALUE(unsigned int, u)
-        CATCH_VALUE(unsigned long, lu)
-        CATCH_VALUE(unsigned long long, llu)
-        CATCH_VALUE(float, f)
-        CATCH_VALUE(double, f)
-        CATCH_VALUE(long double, Lf)
-        CATCH_VALUE(char *, s)
-        catch (...) { description = NULL; }
+catch (TYPE value) { snprintf(descriptionBuff, sizeof(descriptionBuff), "%" #PRINTFTYPE, value); \
+}
+            CATCH_VALUE(char, d)
+            CATCH_VALUE(short, d)
+            CATCH_VALUE(int, d)
+            CATCH_VALUE(long, ld)
+            CATCH_VALUE(long long, lld)
+            CATCH_VALUE(unsigned char, u)
+            CATCH_VALUE(unsigned short, u)
+            CATCH_VALUE(unsigned int, u)
+            CATCH_VALUE(unsigned long, lu)
+            CATCH_VALUE(unsigned long long, llu)
+            CATCH_VALUE(float, f)
+            CATCH_VALUE(double, f)
+            CATCH_VALUE(long double, Lf)
+            CATCH_VALUE(char *, s)
+            catch (...) { description = NULL; }
+        }
         g_captureNextStackTrace = g_isEnabled;
 
         // TODO: Should this be done here? Maybe better in the exception handler?
@@ -187,9 +204,17 @@ static void CPPExceptionTerminate(void)
             description = "unable to determine C++ exception type";
         }
         ksmc_fillMonitorContext(crashContext, kscm_cppexception_getAPI());
+
+        KSStackCursor cursor;
+        if (g_stackTraceCount != 0) {
+            kssc_initWithBacktrace(&cursor, g_stackTrace, g_stackTraceCount, 1);
+        } else {
+            cursor = g_stackCursor;
+        }
+
         crashContext->eventID = g_eventID;
         crashContext->registersAreValid = false;
-        crashContext->stackCursor = &g_stackCursor;
+        crashContext->stackCursor = &cursor;
         crashContext->CPPException.name = name;
         crashContext->exceptionName = name;
         crashContext->crashReason = description;

--- a/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
+++ b/Sources/KSCrashRecording/Monitors/KSCrashMonitor_Deadlock.m
@@ -148,7 +148,7 @@ static NSTimeInterval g_watchdogInterval = 0;
                 if (self.awaitingResponse) {
                     // Check if app is in foreground
                     if (!kscrashstate_currentState()->applicationIsInForeground) {
-                        KSLOG_INFO("Ignoring app hang because app is in the background");
+                        KSLOG_INFO(@"Ignoring app hang because app is in the background");
                         [self watchdogPulse];
                     } else {
                         [self handleDeadlock];

--- a/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashCConfiguration.h
@@ -220,6 +220,14 @@ typedef struct {
      * **Default**: false
      */
     bool enableSigTermMonitoring;
+
+    /** If true, enables writing all threads info in the report.
+     *
+     * If false, only the offending thread is going to be written to the report.
+     *
+     * **Default**: true
+     */
+    bool threadTracingEnabled;
 } KSCrashCConfiguration;
 
 static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
@@ -238,6 +246,7 @@ static inline KSCrashCConfiguration KSCrashCConfiguration_Default(void)
         .printPreviousLogOnStartup = false,
         .enableSwapCxaThrow = true,
         .enableSigTermMonitoring = false,
+        .threadTracingEnabled = true,
     };
 }
 

--- a/Sources/KSCrashRecording/include/KSCrashConfiguration.h
+++ b/Sources/KSCrashRecording/include/KSCrashConfiguration.h
@@ -164,6 +164,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, assign) BOOL enableSigTermMonitoring;
 
+/** If true, enables writing all threads info in the report.
+ *
+ * If false, only the offending thread is going to be written to the report.
+ *
+ * **Default**: true
+ */
+@property(nonatomic, assign) BOOL threadTracingEnabled;
+
 @end
 
 NS_SWIFT_NAME(CrashReportStoreConfiguration)

--- a/Sources/KSCrashRecordingCore/KSMach.c
+++ b/Sources/KSCrashRecordingCore/KSMach.c
@@ -27,6 +27,18 @@
 #include <mach/mach.h>
 #include <stdlib.h>
 
+#define EXC_UNIX_BAD_SYSCALL 0x10000    /* SIGSYS */
+#define EXC_UNIX_BAD_PIPE    0x10001    /* SIGPIPE */
+#define EXC_UNIX_ABORT       0x10002    /* SIGABRT */
+/*
+ *      EXC_BAD_ACCESS
+ *      Note: do not conflict with kern_return_t values returned by vm_fault
+ */
+#define EXC_ARM_DA_ALIGN    0x101    /* Alignment Fault */
+#define EXC_ARM_DA_DEBUG    0x102    /* Debug (watch/break) Fault */
+#define EXC_ARM_SP_ALIGN    0x103    /* SP Alignment Fault */
+#define EXC_ARM_SWP         0x104    /* SWP instruction */
+
 #define RETURN_NAME_FOR_ENUM(A) \
     case A:                     \
         return #A
@@ -102,13 +114,14 @@ const char *ksmach_kernelReturnCodeName(const int64_t returnCode)
         RETURN_NAME_FOR_ENUM(KERN_NOT_WAITING);
         RETURN_NAME_FOR_ENUM(KERN_OPERATION_TIMED_OUT);
         RETURN_NAME_FOR_ENUM(KERN_CODESIGN_ERROR);
+        // Note: these are only valid for EXC_BAD_ACCESS
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_DEBUG);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SP_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SWP);
     }
     return NULL;
 }
-
-#define EXC_UNIX_BAD_SYSCALL 0x10000 /* SIGSYS */
-#define EXC_UNIX_BAD_PIPE 0x10001    /* SIGPIPE */
-#define EXC_UNIX_ABORT 0x10002       /* SIGABRT */
 
 int ksmach_machExceptionForSignal(const int sigNum)
 {


### PR DESCRIPTION
Add option for not writing threads to the report.
Add handling for EXC_BAD_ACCESS exception codes.
Handle empty throw, add backtrace for it.